### PR TITLE
chore(deps): fix critical + high security advisories

### DIFF
--- a/agents/requirements.txt
+++ b/agents/requirements.txt
@@ -19,8 +19,8 @@ aws-opentelemetry-distro==0.17.1
 pydantic==2.12.5  # Data validation for models
 
 # Authentication and security
-PyJWT==2.12.1  # JWT token validation
-cryptography==46.0.6  # Cryptographic functions for JWT
+PyJWT==2.13.0  # JWT token validation
+cryptography==48.0.1  # Cryptographic functions for JWT
 
 # HTTP client
 aiohttp==3.13.3  # Async HTTP client (required by smithy-http)

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-cdk/aws-bedrock-agentcore-alpha": "2.245.0-alpha.0",
+        "@aws-cdk/aws-bedrock-agentcore-alpha": "2.246.0-alpha.0",
         "@aws-sdk/client-codebuild": "3.990.0",
-        "aws-cdk-lib": "2.245.0",
+        "aws-cdk-lib": "2.246.0",
         "cdk-nag": "2.37.55",
         "constructs": "10.5.1",
         "esbuild": "0.27.4"
@@ -40,30 +40,30 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/aws-bedrock-agentcore-alpha": {
-      "version": "2.245.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-bedrock-agentcore-alpha/-/aws-bedrock-agentcore-alpha-2.245.0-alpha.0.tgz",
-      "integrity": "sha512-4H9QGWGiOb73iuNbJjGYGZC8lTYwB0E4FH6Zm7Ni9Hx0OjbRGrLRGwrE5EQAt70Gbi52tbQb1JXpEx6rnp0C7Q==",
+      "version": "2.246.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-bedrock-agentcore-alpha/-/aws-bedrock-agentcore-alpha-2.246.0-alpha.0.tgz",
+      "integrity": "sha512-mLcXYG5OiHGXFI+lW/Yv6lQGSMg0Q41MiBbclRogueczADglAXRT3/4/n+2TuI7MJuGD1LzZOdVn/s2ssWP2Mw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-bedrock-alpha": "2.245.0-alpha.0",
-        "aws-cdk-lib": "^2.245.0",
+        "@aws-cdk/aws-bedrock-alpha": "2.246.0-alpha.0",
+        "aws-cdk-lib": "^2.246.0",
         "constructs": "^10.5.0"
       }
     },
     "node_modules/@aws-cdk/aws-bedrock-alpha": {
-      "version": "2.245.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-bedrock-alpha/-/aws-bedrock-alpha-2.245.0-alpha.0.tgz",
-      "integrity": "sha512-Dje8/jCo+V1bhd/UuwxZajLpiFpmOehOTjLWQc3BValgMorzciDmjMiu8myx5Egk2eAZ0W3OuJalB89QV4Z8kw==",
+      "version": "2.246.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-bedrock-alpha/-/aws-bedrock-alpha-2.246.0-alpha.0.tgz",
+      "integrity": "sha512-+plEwWlZf4hGVhJHLGzH4fcpSbSAq2vXpwizZBEan0kkaxGUYRRCKxit5oX2AZ82E6v8kqci0KAEfI+Spni3IQ==",
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.245.0",
+        "aws-cdk-lib": "^2.246.0",
         "constructs": "^10.5.0"
       }
     },
@@ -2554,9 +2554,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.245.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.245.0.tgz",
-      "integrity": "sha512-Yfeb+wKC6s+Ttm/N93C6vY6ksyCh68WaG/j3N6dalJWTW/V4o6hUolHm+v2c2IofJEUS45c5AF/EEj24e9hfMA==",
+      "version": "2.246.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.246.0.tgz",
+      "integrity": "sha512-7OtF95mss9dWohopCNQKAlNFrMJwgOIvNTNgoOWWcKhULBf6UxKCaf6ATlnuysIWRGf2DHgcval/4+yySOKRBw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -35,9 +35,9 @@
     "typescript": "5.9.3"
   },
   "dependencies": {
-    "@aws-cdk/aws-bedrock-agentcore-alpha": "2.245.0-alpha.0",
+    "@aws-cdk/aws-bedrock-agentcore-alpha": "2.246.0-alpha.0",
     "@aws-sdk/client-codebuild": "3.990.0",
-    "aws-cdk-lib": "2.245.0",
+    "aws-cdk-lib": "2.246.0",
     "cdk-nag": "2.37.55",
     "constructs": "10.5.1",
     "esbuild": "0.27.4"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1310,13 +1310,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.27.tgz",
-      "integrity": "sha512-hpsCXCOI436kxWpjtRuIHVvuPP81MOw8f18jzfZeg+UOiiOvlqWcmWChzEhJEu16cOC6+ku4ncBN+7rdt+DZ9g==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
+      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.3",
-        "fast-xml-parser": "5.7.3",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6686,9 +6685,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
-      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
+      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -11822,22 +11821,22 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
-      "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.20.1",
+        "ws": "~8.21.0",
         "xmlhttprequest-ssl": "~2.1.1"
       }
     },
     "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -13479,16 +13478,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -14034,9 +14033,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -22115,9 +22114,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "serialize-javascript": ">=7.0.3",
     "underscore": ">=1.13.8",
     "fast-xml-parser": "5.5.8",
-    "socket.io-parser": "4.2.6"
+    "socket.io-parser": "4.2.6",
+    "shell-quote": ">=1.8.4"
   }
 }


### PR DESCRIPTION
## Summary

Addresses the Dependabot **1 critical + several high** advisories that can be fixed without breaking-change major bumps. Scoped to lockfile-safe fixes and direct-pin bumps.

## Fixed

**Critical**
- `shell-quote` → **1.9.0** (was 1.8.3) via `overrides` — CVE-2026-9277 command injection (dev-scope, build tooling).

**High — direct pins**
- `cryptography` 46.0.6 → **48.0.1** (`agents/requirements.txt`)
- `PyJWT` 2.12.1 → **2.13.0** (`agents/requirements.txt`)
- `aws-cdk-lib` + `@aws-cdk/aws-bedrock-agentcore-alpha` 2.245.0 → **2.246.0** (`cdk/package.json`)

**High — transitive (npm audit fix, prod scope)**
- `form-data` → 4.0.6 (prod) — CRLF injection
- `ws` → 8.21.0 — DoS

## Deferred (not in this PR — need breaking changes or upstream)

- **`jackson-databind`** → handled by Dependabot **PR #34**.
- **`form-data` 3.0.4 / `ws` 7.x** — pulled in only by `launch-editor` (dev); Dependabot **PR #30** bumps it.
- **`lodash`** — bundled under `react-scripts`; `npm audit fix --force` would install `react-scripts@0.0.0` (destructive). Needs a deliberate react-scripts migration.
- **`fast-uri`** — bundled *inside* `aws-cdk-lib`; npm overrides can't touch bundled deps. Clears when aws-cdk-lib ships a patched copy.
- **`esbuild`** (cdk, dev) — fix requires a breaking major.

## Note on source of truth

`agents/requirements.txt`, `cdk/package.json` also live on the internal `main` (GitLab). These pin bumps should be mirrored there so the next public sync doesn't revert them.

## Verification

- `npm audit` (cdk + frontend, `--package-lock-only`): **0 critical** remaining. Remaining highs are the deferred set above.
- No production `agents/` logic changed; only dependency versions/lockfiles.